### PR TITLE
Use latest (hopefully last) alpha of eslint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {},
   "devDependencies": {
     "eslint": "^3.4.0",
-    "eslint-config-finn": "1.0.0-alpha.9",
+    "eslint-config-finn": "1.0.0-alpha.11",
     "eslint-config-finn-react": "^1.0.0-alpha.2",
     "eslint-plugin-react": "^6.2.0",
     "lerna": "2.0.0-beta.20",

--- a/packages/unleash-api/.eslintrc
+++ b/packages/unleash-api/.eslintrc
@@ -1,10 +1,9 @@
 {
     "extends": [
         "finn",
-        "finn/es6",
         "finn/node"
     ],
     "rules": {
-        "max-nested-callbacks": [0]
+        "max-nested-callbacks": "off"
     }
 }

--- a/packages/unleash-frontend/.eslintrc
+++ b/packages/unleash-frontend/.eslintrc
@@ -1,7 +1,6 @@
 {
     "extends": [
         "finn",
-        "finn/es6",
         "finn/node"
     ]
 }

--- a/packages/unleash-frontend/public/.eslintrc
+++ b/packages/unleash-frontend/public/.eslintrc
@@ -1,7 +1,6 @@
 {
     "extends": [
         "finn",
-        "finn/es6",
         "finn-react"
     ],
     "env": {
@@ -9,6 +8,6 @@
         "commonjs": true
     },
     "rules": {
-        "react/sort-comp": [0]
+        "react/sort-comp": "off"
     }
 }

--- a/packages/unleash-frontend/public/js/__tests__/.eslintrc
+++ b/packages/unleash-frontend/public/js/__tests__/.eslintrc
@@ -1,8 +1,7 @@
 {
     "extends": [
         "finn",
-        "finn/node",
-        "finn/es6"
+        "finn/node"
     ],
     "env": {
         "browser": true,


### PR DESCRIPTION
Should be the last one before full release.

Not necessary to merge this I suppose, could morph into stable pretty soon